### PR TITLE
DI-1076 public repo update

### DIFF
--- a/www/_template.html
+++ b/www/_template.html
@@ -30,40 +30,28 @@
   <!-- END HEADER -->
   <div class="container-fluid">
     <!-- START NAVIGATION -->
-    <div class="row">
+		<div class="row">
       <div class="col-sm-3 col-md-2 sidebar">
 		    <ul class="nav nav-sidebar">
-          <li class="mainNavHeader active"><a href="/index.html">Overview</a></li>
-          <li><a href="/more.html">Learn More</a></li>
-          <li><a href="/example-01.html">Example</a></li>
+          <li class="mainNavHeader active"><a href="index.html">Overview</a></li>
+          <li><a href="more.html">Learn More</a></li>
+          <li><a href="example-01.html">Example</a></li>
+					<li><a href="version.html">Version</a></li>
         </ul>
 		    <ul class="nav nav-sidebar">
           <li class="mainNavHeader"><a href="/rest.html">REST API</a></li>
-          <li><a href="/rest.html#Security">Security</a></li>
-          <li><a href="/rest.html#Resource">Resource</a></li>
-          <li><a href="/rest.html#Query">Query</a></li>
-          <li><a href="/rest.html#Process">Process</a></li>
-          <li><a href="/rest.html#Result">Result</a></li>
+          <li><a href="rest.html#Security">Security</a></li>
+          <li><a href="rest.html#Resource">Resource</a></li>
+          <li><a href="rest.html#Query">Query</a></li>
+          <li><a href="rest.html#Process">Process</a></li>
+          <li><a href="rest.html#Result">Result</a></li>
         </ul>
-        <ul class="nav nav-sidebar">
-          <li class="mainNavHeader"><a href="#">IRCT-CL</a></li>
-          <li><a target="_blank" href="https://github.com/hms-dbmi/IRCT-CL" class="componentOutLink">GitHub</a></li>
-          <li><a href="/IRCT-CL/index.html">JavaDoc</a></li>
-        </ul>
-        <ul class="nav nav-sidebar">
-          <li class="mainNavHeader"><a href="#">IRCT-API</a></li>
-          <li><a target="_blank" href="https://github.com/hms-dbmi/IRCT-API" class="componentOutLink">GitHub</a></li>
-          <li><a href="/IRCT-API/index.html">JavaDoc</a></li>
-        </ul>
-        <ul class="nav nav-sidebar">
-          <li class="mainNavHeader"><a href="#">IRCT-EXT</a></li>
-          <li><a target="_blank" href="https://github.com/hms-dbmi/IRCT-EXT" class="componentOutLink">GitHub</a></li>
-          <li><a href="/IRCT-EXT/index.html">JavaDoc</a></li>
-        </ul>
-        <ul class="nav nav-sidebar">
-          <li class="mainNavHeader"><a href="#">IRCT-RI</a></li>
-          <li><a target="_blank" href="https://github.com/hms-dbmi/IRCT-RI" class="componentOutLink">GitHub</a></li>
-          <li><a href="/IRCT-RI/index.html">JavaDoc</a></li>
+				<ul class="nav nav-sidebar">
+          <li class="mainNavHeader"><a href="https://github.com/hms-dbmi/IRCT" target="_blank">IRCT Repo (GitHub)</a></li>
+          <li><a target="_blank" href="https://github.com/hms-dbmi/IRCT/tree/master/IRCT-CL" > CL</a></li>
+          <li><a target="_blank" href="https://github.com/hms-dbmi/IRCT/tree/master/IRCT-API" > API</a></li>
+          <li><a target="_blank" href="https://github.com/hms-dbmi/IRCT/tree/master/IRCT-EXT" > EXT</a></li>
+          <li><a target="_blank" href="https://github.com/hms-dbmi/IRCT/tree/master/IRCT-RI" > RI</a></li>
         </ul>
       </div>
     </div>
@@ -73,7 +61,7 @@
         STUFF GOES HERE
       </div>
   </div>
-  
+
   <!-- Bootstrap JS -->
 <script src="./bower_components/jquery/dist/jquery.min.js"></script>
 <script src="./bower_components/bootstrap/dist/js/bootstrap.min.js"></script>

--- a/www/bower.json
+++ b/www/bower.json
@@ -1,10 +1,10 @@
 {
-  "name": "HMS ExAC",
-  "homepage": "http://exac.hms.harvard.edu",
+  "name": "BD2K PIC-SURE RESTful API",
+  "homepage": "http://bd2k-picsure.hms.harvard.edu/",
   "authors": [
-    "(Jeremy R. Easton-Marks <Jeremy_Easton-Marks@hms.harvard.edu>)"
+    "(Avillach Lab Developers <avillach_lab_developers@googlegroups.com>)"
   ],
-  "description": "The HMS ExAC API adds REST API functionality to the ExAC Web Browser",
+  "description": "The BD2K PIC-SURE IRCT-UI provides a set of reusable components that interact with the IRCT application.",
   "main": "index.html",
   "license": "MPL2",
   "private": true,

--- a/www/css/main.css
+++ b/www/css/main.css
@@ -160,7 +160,7 @@ body {
  }
 
  .versionText {
-   
+
  }
 
 /**
@@ -192,7 +192,9 @@ body {
     width: 100%;
 }
 
-.componentOutCell {text-align: center;}
+.componentOutCell {
+  text-align: center;
+}
 
 /**
  * Animation

--- a/www/example-01.html
+++ b/www/example-01.html
@@ -30,41 +30,28 @@
   <!-- END HEADER -->
   <div class="container-fluid">
     <!-- START NAVIGATION -->
-    <div class="row">
+		<div class="row">
       <div class="col-sm-3 col-md-2 sidebar">
 		    <ul class="nav nav-sidebar">
-          <li class="mainNavHeader"><a href="/index.html">Overview</a></li>
-          <li><a href="/more.html">Learn More</a></li>
-          <li class="active"><a href="/example-01.html">Example</a></li>
-					<li><a href="/version.html">Version</a></li>
+          <li class="mainNavHeader active"><a href="/index.html">Overview</a></li>
+          <li><a href="more.html">Learn More</a></li>
+          <li><a href="example-01.html">Example</a></li>
+					<li><a href="version.html">Version</a></li>
         </ul>
 		    <ul class="nav nav-sidebar">
           <li class="mainNavHeader"><a href="/rest.html">REST API</a></li>
-          <li><a href="/rest.html#Security">Security</a></li>
-          <li><a href="/rest.html#Resource">Resource</a></li>
-          <li><a href="/rest.html#Query">Query</a></li>
-          <li><a href="/rest.html#Process">Process</a></li>
-          <li><a href="/rest.html#Result">Result</a></li>
+          <li><a href="rest.html#Security">Security</a></li>
+          <li><a href="rest.html#Resource">Resource</a></li>
+          <li><a href="rest.html#Query">Query</a></li>
+          <li><a href="rest.html#Process">Process</a></li>
+          <li><a href="rest.html#Result">Result</a></li>
         </ul>
-        <ul class="nav nav-sidebar">
-          <li class="mainNavHeader"><a href="#">IRCT-CL</a></li>
-          <li><a target="_blank" href="https://github.com/hms-dbmi/IRCT-CL" class="componentOutLink">GitHub</a></li>
-          <li><a href="/IRCT-CL/index.html">JavaDoc</a></li>
-        </ul>
-        <ul class="nav nav-sidebar">
-          <li class="mainNavHeader"><a href="#">IRCT-API</a></li>
-          <li><a target="_blank" href="https://github.com/hms-dbmi/IRCT-API" class="componentOutLink">GitHub</a></li>
-          <li><a href="/IRCT-API/index.html">JavaDoc</a></li>
-        </ul>
-        <ul class="nav nav-sidebar">
-          <li class="mainNavHeader"><a href="#">IRCT-EXT</a></li>
-          <li><a target="_blank" href="https://github.com/hms-dbmi/IRCT-EXT" class="componentOutLink">GitHub</a></li>
-          <li><a href="/IRCT-EXT/index.html">JavaDoc</a></li>
-        </ul>
-        <ul class="nav nav-sidebar">
-          <li class="mainNavHeader"><a href="#">IRCT-RI</a></li>
-          <li><a target="_blank" href="https://github.com/hms-dbmi/IRCT-RI" class="componentOutLink">GitHub</a></li>
-          <li><a href="/IRCT-RI/index.html">JavaDoc</a></li>
+				<ul class="nav nav-sidebar">
+          <li class="mainNavHeader"><a href="https://github.com/hms-dbmi/IRCT" target="_blank">IRCT Repo (GitHub)</a></li>
+          <li><a target="_blank" href="https://github.com/hms-dbmi/IRCT/tree/master/IRCT-CL" > CL</a></li>
+          <li><a target="_blank" href="https://github.com/hms-dbmi/IRCT/tree/master/IRCT-API" > API</a></li>
+          <li><a target="_blank" href="https://github.com/hms-dbmi/IRCT/tree/master/IRCT-EXT" > EXT</a></li>
+          <li><a target="_blank" href="https://github.com/hms-dbmi/IRCT/tree/master/IRCT-RI" > RI</a></li>
         </ul>
       </div>
     </div>

--- a/www/index.html
+++ b/www/index.html
@@ -6,7 +6,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="description"
 	content="The BD2K PIC-SURE IRCT-UI provides a set of reusable components that interact with the IRCT application.">
-<meta name="author" content="Jeremy R. Easton-Marks">
+<meta name="author" content="avillach_lab_developers">
 
 <title>BD2K PIC-SURE RESTful API</title>
 
@@ -33,38 +33,25 @@
     <div class="row">
       <div class="col-sm-3 col-md-2 sidebar">
 		    <ul class="nav nav-sidebar">
-          <li class="mainNavHeader active"><a href="/index.html">Overview</a></li>
-          <li><a href="/more.html">Learn More</a></li>
-          <li><a href="/example-01.html">Example</a></li>
-					<li><a href="/version.html">Version</a></li>
+          <li class="mainNavHeader active"><a href="index.html">Overview</a></li>
+          <li><a href="more.html">Learn More</a></li>
+          <li><a href="example-01.html">Example</a></li>
+					<li><a href="version.html">Version</a></li>
         </ul>
 		    <ul class="nav nav-sidebar">
           <li class="mainNavHeader"><a href="/rest.html">REST API</a></li>
-          <li><a href="/rest.html#Security">Security</a></li>
-          <li><a href="/rest.html#Resource">Resource</a></li>
-          <li><a href="/rest.html#Query">Query</a></li>
-          <li><a href="/rest.html#Process">Process</a></li>
-          <li><a href="/rest.html#Result">Result</a></li>
+          <li><a href="rest.html#Security">Security</a></li>
+          <li><a href="rest.html#Resource">Resource</a></li>
+          <li><a href="rest.html#Query">Query</a></li>
+          <li><a href="rest.html#Process">Process</a></li>
+          <li><a href="rest.html#Result">Result</a></li>
         </ul>
-        <ul class="nav nav-sidebar">
-          <li class="mainNavHeader"><a href="#">IRCT-CL</a></li>
-          <li><a target="_blank" href="https://github.com/hms-dbmi/IRCT-CL" class="componentOutLink">GitHub</a></li>
-          <li><a href="/IRCT-CL/index.html">JavaDoc</a></li>
-        </ul>
-        <ul class="nav nav-sidebar">
-          <li class="mainNavHeader"><a href="#">IRCT-API</a></li>
-          <li><a target="_blank" href="https://github.com/hms-dbmi/IRCT-API" class="componentOutLink">GitHub</a></li>
-          <li><a href="/IRCT-API/index.html">JavaDoc</a></li>
-        </ul>
-        <ul class="nav nav-sidebar">
-          <li class="mainNavHeader"><a href="#">IRCT-EXT</a></li>
-          <li><a target="_blank" href="https://github.com/hms-dbmi/IRCT-EXT" class="componentOutLink">GitHub</a></li>
-          <li><a href="/IRCT-EXT/index.html">JavaDoc</a></li>
-        </ul>
-        <ul class="nav nav-sidebar">
-          <li class="mainNavHeader"><a href="#">IRCT-RI</a></li>
-          <li><a target="_blank" href="https://github.com/hms-dbmi/IRCT-RI" class="componentOutLink">GitHub</a></li>
-          <li><a href="/IRCT-RI/index.html">JavaDoc</a></li>
+				<ul class="nav nav-sidebar">
+          <li class="mainNavHeader"><a href="https://github.com/hms-dbmi/IRCT" target="_blank">IRCT Repo (GitHub)</a></li>
+          <li><a target="_blank" href="https://github.com/hms-dbmi/IRCT/tree/master/IRCT-CL" > CL</a></li>
+          <li><a target="_blank" href="https://github.com/hms-dbmi/IRCT/tree/master/IRCT-API" > API</a></li>
+          <li><a target="_blank" href="https://github.com/hms-dbmi/IRCT/tree/master/IRCT-EXT" > EXT</a></li>
+          <li><a target="_blank" href="https://github.com/hms-dbmi/IRCT/tree/master/IRCT-RI" > RI</a></li>
         </ul>
       </div>
     </div>

--- a/www/index.html
+++ b/www/index.html
@@ -39,7 +39,7 @@
 					<li><a href="version.html">Version</a></li>
         </ul>
 		    <ul class="nav nav-sidebar">
-          <li class="mainNavHeader"><a href="/rest.html">REST API</a></li>
+          <li class="mainNavHeader"><a href="rest.html">REST API</a></li>
           <li><a href="rest.html#Security">Security</a></li>
           <li><a href="rest.html#Resource">Resource</a></li>
           <li><a href="rest.html#Query">Query</a></li>
@@ -47,11 +47,11 @@
           <li><a href="rest.html#Result">Result</a></li>
         </ul>
 				<ul class="nav nav-sidebar">
-          <li class="mainNavHeader"><a href="https://github.com/hms-dbmi/IRCT" target="_blank">IRCT Repo (GitHub)</a></li>
-          <li><a target="_blank" href="https://github.com/hms-dbmi/IRCT/tree/master/IRCT-CL" > CL</a></li>
-          <li><a target="_blank" href="https://github.com/hms-dbmi/IRCT/tree/master/IRCT-API" > API</a></li>
-          <li><a target="_blank" href="https://github.com/hms-dbmi/IRCT/tree/master/IRCT-EXT" > EXT</a></li>
-          <li><a target="_blank" href="https://github.com/hms-dbmi/IRCT/tree/master/IRCT-RI" > RI</a></li>
+          <li class="mainNavHeader"><a href="https://github.com/hms-dbmi/IRCT" target="_blank">IRCT Repo (GitHub) <span><img src="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/PjxzdmcgaGVpZ2h0PSIxMDI0IiB3aWR0aD0iNzY4IiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxwYXRoIGQ9Ik02NDAgNzY4SDEyOFYyNTcuOTA1OTk5OTk5OTk5OTVMMjU2IDI1NlYxMjhIMHY3NjhoNzY4VjU3Nkg2NDBWNzY4ek0zODQgMTI4bDEyOCAxMjhMMzIwIDQ0OGwxMjggMTI4IDE5Mi0xOTIgMTI4IDEyOFYxMjhIMzg0eiIvPjwvc3ZnPg==" style="width: 16px"/></span></a></li>
+          <li><a target="_blank" href="https://github.com/hms-dbmi/IRCT/tree/master/IRCT-CL" > CL <span><img src="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/PjxzdmcgaGVpZ2h0PSIxMDI0IiB3aWR0aD0iNzY4IiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxwYXRoIGQ9Ik02NDAgNzY4SDEyOFYyNTcuOTA1OTk5OTk5OTk5OTVMMjU2IDI1NlYxMjhIMHY3NjhoNzY4VjU3Nkg2NDBWNzY4ek0zODQgMTI4bDEyOCAxMjhMMzIwIDQ0OGwxMjggMTI4IDE5Mi0xOTIgMTI4IDEyOFYxMjhIMzg0eiIvPjwvc3ZnPg==" style="width: 16px"/></span></a></li>
+          <li><a target="_blank" href="https://github.com/hms-dbmi/IRCT/tree/master/IRCT-API" > API <span><img src="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/PjxzdmcgaGVpZ2h0PSIxMDI0IiB3aWR0aD0iNzY4IiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxwYXRoIGQ9Ik02NDAgNzY4SDEyOFYyNTcuOTA1OTk5OTk5OTk5OTVMMjU2IDI1NlYxMjhIMHY3NjhoNzY4VjU3Nkg2NDBWNzY4ek0zODQgMTI4bDEyOCAxMjhMMzIwIDQ0OGwxMjggMTI4IDE5Mi0xOTIgMTI4IDEyOFYxMjhIMzg0eiIvPjwvc3ZnPg==" style="width: 16px"/></span></a></li>
+          <li><a target="_blank" href="https://github.com/hms-dbmi/IRCT/tree/master/IRCT-EXT" > EXT <span><img src="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/PjxzdmcgaGVpZ2h0PSIxMDI0IiB3aWR0aD0iNzY4IiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxwYXRoIGQ9Ik02NDAgNzY4SDEyOFYyNTcuOTA1OTk5OTk5OTk5OTVMMjU2IDI1NlYxMjhIMHY3NjhoNzY4VjU3Nkg2NDBWNzY4ek0zODQgMTI4bDEyOCAxMjhMMzIwIDQ0OGwxMjggMTI4IDE5Mi0xOTIgMTI4IDEyOFYxMjhIMzg0eiIvPjwvc3ZnPg==" style="width: 16px"/></span></a></li>
+          <li><a target="_blank" href="https://github.com/hms-dbmi/IRCT/tree/master/IRCT-RI" > RI <span><img src="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/PjxzdmcgaGVpZ2h0PSIxMDI0IiB3aWR0aD0iNzY4IiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxwYXRoIGQ9Ik02NDAgNzY4SDEyOFYyNTcuOTA1OTk5OTk5OTk5OTVMMjU2IDI1NlYxMjhIMHY3NjhoNzY4VjU3Nkg2NDBWNzY4ek0zODQgMTI4bDEyOCAxMjhMMzIwIDQ0OGwxMjggMTI4IDE5Mi0xOTIgMTI4IDEyOFYxMjhIMzg0eiIvPjwvc3ZnPg==" style="width: 16px"/></span></a></li>
         </ul>
       </div>
     </div>
@@ -78,35 +78,18 @@
         <div class="col-xs-3  col-sm-3 componentCol">
           <span class="componentTitle">IRCT-CL</span>
           <p class="componentText">The IRCT Communication Layer (IRCT-CL) provides a resource agnostic Representative State Transfer (RESTful) service. Users build queries by making a series of calls to the RESTful service that can span multiple datasets and resources.</p>
-          <div class="linkRow">
-            <div class="col-xs-4 col-sm-4 componentOutCell"><a target="_blank" href="https://github.com/hms-dbmi/IRCT-CL" class="componentOutLink">GITHUB</a></div>
-            <div class="col-xs-4 col-sm-4 componentOutCell"><a href="/IRCT-CL/index.html" class="componentOutLink">JAVADOC</a></div>
-            <div class="col-xs-4 col-sm-4 componentOutCell"><a href="/rest.html" class="componentOutLink">REST API</a></div>
-          </div>
         </div>
         <div class="col-xs-3  col-sm-3 componentCol">
           <span class="componentTitle">IRCT-API</span>
           <p class="componentText">The IRCT Application Programming Interface (IRCT-API) is the core of the IRCT project. It manages the queries for data, and processing across the different resources.</p>
-          <div class="linkRow">
-            <div class="col-xs-6 col-sm-6 componentOutCell"><a target="_blank" href="https://github.com/hms-dbmi/IRCT-API" class="componentOutLink">GITHUB</a></div>
-            <div class="col-xs-6 col-sm-6 componentOutCell"><a href="/IRCT-API/index.html" class="componentOutLink">JAVADOC</a></div>
-          </div>
         </div>
          <div class="col-xs-3  col-sm-3 componentCol">
           <span class="componentTitle">IRCT-EXT</span>
           <p class="componentText">The IRCT Extension (IRCT-EXT) provides a way of adding additional functionality to an IRCT instance. Administrators can add any number of additional features without having to make code changes.</p>
-          <div class="linkRow">
-            <div class="col-xs-6 col-sm-6 componentOutCell"><a target="_blank" href="https://github.com/hms-dbmi/IRCT-EXT" class="componentOutLink">GITHUB</a></div>
-            <div class="col-xs-6 col-sm-6 componentOutCell"><a href="/IRCT-EXT/index.html" class="componentOutLink">JAVADOC</a></div>
-          </div>
         </div>
         <div class="col-xs-3  col-sm-3 componentCol">
           <span class="componentTitle">IRCT-RI</span>
           <p class="componentText">The IRCT Resource Interface (IRCT-RI) provides a way of connecting the IRCT application to different resources for querying. Included in the project are interfaces to both i2b2, i2b2/tranSMART, and the ExAC browser.</p>
-          <div class="linkRow">
-            <div class="col-xs-6 col-sm-6 componentOutCell"><a target="_blank" href="https://github.com/hms-dbmi/IRCT-RI" class="componentOutLink">GITHUB</a></div>
-            <div class="col-xs-6 col-sm-6 componentOutCell"><a href="./IRCT-RI/index.html" class="componentOutLink">JAVADOC</a></div>
-          </div>
         </div>
       </div>
   </div>

--- a/www/more.html
+++ b/www/more.html
@@ -30,41 +30,28 @@
   <!-- END HEADER -->
   <div class="container-fluid">
     <!-- START NAVIGATION -->
-    <div class="row">
+		<div class="row">
       <div class="col-sm-3 col-md-2 sidebar">
 		    <ul class="nav nav-sidebar">
-          <li class="mainNavHeader"><a href="/index.html">Overview</a></li>
-          <li class="active"><a href="/more.html">Learn More</a></li>
-          <li><a href="/example-01.html">Example</a></li>
-					<li><a href="/version.html">Version</a></li>
+          <li class="mainNavHeader active"><a href="/index.html">Overview</a></li>
+          <li><a href="more.html">Learn More</a></li>
+          <li><a href="example-01.html">Example</a></li>
+					<li><a href="version.html">Version</a></li>
         </ul>
 		    <ul class="nav nav-sidebar">
           <li class="mainNavHeader"><a href="/rest.html">REST API</a></li>
-          <li><a href="/rest.html#Security">Security</a></li>
-          <li><a href="/rest.html#Resource">Resource</a></li>
-          <li><a href="/rest.html#Query">Query</a></li>
-          <li><a href="/rest.html#Process">Process</a></li>
-          <li><a href="/rest.html#Result">Result</a></li>
+          <li><a href="rest.html#Security">Security</a></li>
+          <li><a href="rest.html#Resource">Resource</a></li>
+          <li><a href="rest.html#Query">Query</a></li>
+          <li><a href="rest.html#Process">Process</a></li>
+          <li><a href="rest.html#Result">Result</a></li>
         </ul>
-       <ul class="nav nav-sidebar">
-          <li class="mainNavHeader"><a href="#">IRCT-CL</a></li>
-          <li><a target="_blank" href="https://github.com/hms-dbmi/IRCT-CL" class="componentOutLink">GitHub</a></li>
-          <li><a href="/IRCT-CL/index.html">JavaDoc</a></li>
-        </ul>
-        <ul class="nav nav-sidebar">
-          <li class="mainNavHeader"><a href="#">IRCT-API</a></li>
-          <li><a target="_blank" href="https://github.com/hms-dbmi/IRCT-API" class="componentOutLink">GitHub</a></li>
-          <li><a href="/IRCT-API/index.html">JavaDoc</a></li>
-        </ul>
-        <ul class="nav nav-sidebar">
-          <li class="mainNavHeader"><a href="#">IRCT-EXT</a></li>
-          <li><a target="_blank" href="https://github.com/hms-dbmi/IRCT-EXT" class="componentOutLink">GitHub</a></li>
-          <li><a href="/IRCT-EXT/index.html">JavaDoc</a></li>
-        </ul>
-        <ul class="nav nav-sidebar">
-          <li class="mainNavHeader"><a href="#">IRCT-RI</a></li>
-          <li><a target="_blank" href="https://github.com/hms-dbmi/IRCT-RI" class="componentOutLink">GitHub</a></li>
-          <li><a href="/IRCT-RI/index.html">JavaDoc</a></li>
+				<ul class="nav nav-sidebar">
+          <li class="mainNavHeader"><a href="https://github.com/hms-dbmi/IRCT" target="_blank">IRCT Repo (GitHub)</a></li>
+          <li><a target="_blank" href="https://github.com/hms-dbmi/IRCT/tree/master/IRCT-CL" > CL</a></li>
+          <li><a target="_blank" href="https://github.com/hms-dbmi/IRCT/tree/master/IRCT-API" > API</a></li>
+          <li><a target="_blank" href="https://github.com/hms-dbmi/IRCT/tree/master/IRCT-EXT" > EXT</a></li>
+          <li><a target="_blank" href="https://github.com/hms-dbmi/IRCT/tree/master/IRCT-RI" > RI</a></li>
         </ul>
       </div>
     </div>

--- a/www/rest.html
+++ b/www/rest.html
@@ -30,41 +30,28 @@
   <!-- END HEADER -->
   <div class="container-fluid">
     <!-- START NAVIGATION -->
-    <div class="row">
+		<div class="row">
       <div class="col-sm-3 col-md-2 sidebar">
 		    <ul class="nav nav-sidebar">
-          <li class="mainNavHeader"><a href="/index.html">Overview</a></li>
-          <li><a href="/more.html">Learn More</a></li>
-          <li><a href="/example-01.html">Example</a></li>
-					<li><a href="/version.html">Version</a></li>
-        </ul>
-        <ul class="nav nav-sidebar scrollable">
-          <li class="active mainNavHeader"><a href="/rest.html#Introduction">REST API</a></li>
-          <li><a href="/rest.html#Security">Security</a></li>
-          <li><a href="/rest.html#Resource">Resource</a></li>
-          <li><a href="/rest.html#Query">Query</a></li>
-          <li><a href="/rest.html#Process">Process</a></li>
-          <li><a href="/rest.html#Result">Result</a></li>
+          <li class="mainNavHeader active"><a href="/index.html">Overview</a></li>
+          <li><a href="more.html">Learn More</a></li>
+          <li><a href="example-01.html">Example</a></li>
+					<li><a href="version.html">Version</a></li>
         </ul>
 		    <ul class="nav nav-sidebar">
-          <li class="mainNavHeader"><a href="#">IRCT-CL</a></li>
-          <li><a target="_blank" href="https://github.com/hms-dbmi/IRCT-CL" class="componentOutLink">GitHub</a></li>
-          <li><a href="/IRCT-CL/index.html">JavaDoc</a></li>
+          <li class="mainNavHeader"><a href="/rest.html">REST API</a></li>
+          <li><a href="rest.html#Security">Security</a></li>
+          <li><a href="rest.html#Resource">Resource</a></li>
+          <li><a href="rest.html#Query">Query</a></li>
+          <li><a href="rest.html#Process">Process</a></li>
+          <li><a href="rest.html#Result">Result</a></li>
         </ul>
-        <ul class="nav nav-sidebar">
-          <li class="mainNavHeader"><a href="#">IRCT-API</a></li>
-          <li><a target="_blank" href="https://github.com/hms-dbmi/IRCT-API" class="componentOutLink">GitHub</a></li>
-          <li><a href="/IRCT-API/index.html">JavaDoc</a></li>
-        </ul>
-        <ul class="nav nav-sidebar">
-          <li class="mainNavHeader"><a href="#">IRCT-EXT</a></li>
-          <li><a target="_blank" href="https://github.com/hms-dbmi/IRCT-EXT" class="componentOutLink">GitHub</a></li>
-          <li><a href="/IRCT-EXT/index.html">JavaDoc</a></li>
-        </ul>
-        <ul class="nav nav-sidebar">
-          <li class="mainNavHeader"><a href="#">IRCT-RI</a></li>
-          <li><a target="_blank" href="https://github.com/hms-dbmi/IRCT-RI" class="componentOutLink">GitHub</a></li>
-          <li><a href="/IRCT-RI/index.html">JavaDoc</a></li>
+				<ul class="nav nav-sidebar">
+          <li class="mainNavHeader"><a href="https://github.com/hms-dbmi/IRCT" target="_blank">IRCT Repo (GitHub)</a></li>
+          <li><a target="_blank" href="https://github.com/hms-dbmi/IRCT/tree/master/IRCT-CL" > CL</a></li>
+          <li><a target="_blank" href="https://github.com/hms-dbmi/IRCT/tree/master/IRCT-API" > API</a></li>
+          <li><a target="_blank" href="https://github.com/hms-dbmi/IRCT/tree/master/IRCT-EXT" > EXT</a></li>
+          <li><a target="_blank" href="https://github.com/hms-dbmi/IRCT/tree/master/IRCT-RI" > RI</a></li>
         </ul>
       </div>
     </div>

--- a/www/version.html
+++ b/www/version.html
@@ -30,41 +30,28 @@
   <!-- END HEADER -->
   <div class="container-fluid">
     <!-- START NAVIGATION -->
-    <div class="row">
+		<div class="row">
       <div class="col-sm-3 col-md-2 sidebar">
 		    <ul class="nav nav-sidebar">
-          <li class="mainNavHeader"><a href="/index.html">Overview</a></li>
-          <li><a href="/more.html">Learn More</a></li>
-          <li><a href="/example-01.html">Example</a></li>
-					<li class="active"><a href="/version.html">Version</a></li>
-        </ul>
-        <ul class="nav nav-sidebar scrollable">
-          <li class="mainNavHeader"><a href="/rest.html#Introduction">REST API</a></li>
-          <li><a href="/rest.html#Security">Security</a></li>
-          <li><a href="/rest.html#Resource">Resource</a></li>
-          <li><a href="/rest.html#Query">Query</a></li>
-          <li><a href="/rest.html#Process">Process</a></li>
-          <li><a href="/rest.html#Result">Result</a></li>
+          <li class="mainNavHeader active"><a href="/index.html">Overview</a></li>
+          <li><a href="more.html">Learn More</a></li>
+          <li><a href="example-01.html">Example</a></li>
+					<li><a href="version.html">Version</a></li>
         </ul>
 		    <ul class="nav nav-sidebar">
-          <li class="mainNavHeader"><a href="#">IRCT-CL</a></li>
-          <li><a target="_blank" href="https://github.com/hms-dbmi/IRCT-CL" class="componentOutLink">GitHub</a></li>
-          <li><a href="/IRCT-CL/index.html">JavaDoc</a></li>
+          <li class="mainNavHeader"><a href="/rest.html">REST API</a></li>
+          <li><a href="rest.html#Security">Security</a></li>
+          <li><a href="rest.html#Resource">Resource</a></li>
+          <li><a href="rest.html#Query">Query</a></li>
+          <li><a href="rest.html#Process">Process</a></li>
+          <li><a href="rest.html#Result">Result</a></li>
         </ul>
-        <ul class="nav nav-sidebar">
-          <li class="mainNavHeader"><a href="#">IRCT-API</a></li>
-          <li><a target="_blank" href="https://github.com/hms-dbmi/IRCT-API" class="componentOutLink">GitHub</a></li>
-          <li><a href="/IRCT-API/index.html">JavaDoc</a></li>
-        </ul>
-        <ul class="nav nav-sidebar">
-          <li class="mainNavHeader"><a href="#">IRCT-EXT</a></li>
-          <li><a target="_blank" href="https://github.com/hms-dbmi/IRCT-EXT" class="componentOutLink">GitHub</a></li>
-          <li><a href="/IRCT-EXT/index.html">JavaDoc</a></li>
-        </ul>
-        <ul class="nav nav-sidebar">
-          <li class="mainNavHeader"><a href="#">IRCT-RI</a></li>
-          <li><a target="_blank" href="https://github.com/hms-dbmi/IRCT-RI" class="componentOutLink">GitHub</a></li>
-          <li><a href="/IRCT-RI/index.html">JavaDoc</a></li>
+				<ul class="nav nav-sidebar">
+          <li class="mainNavHeader"><a href="https://github.com/hms-dbmi/IRCT" target="_blank">IRCT Repo (GitHub)</a></li>
+          <li><a target="_blank" href="https://github.com/hms-dbmi/IRCT/tree/master/IRCT-CL" > CL</a></li>
+          <li><a target="_blank" href="https://github.com/hms-dbmi/IRCT/tree/master/IRCT-API" > API</a></li>
+          <li><a target="_blank" href="https://github.com/hms-dbmi/IRCT/tree/master/IRCT-EXT" > EXT</a></li>
+          <li><a target="_blank" href="https://github.com/hms-dbmi/IRCT/tree/master/IRCT-RI" > RI</a></li>
         </ul>
       </div>
     </div>


### PR DESCRIPTION
This is a temporary change, to point GitHub links to the new public repo. The true solution should be to establish a GitHub Pages site for this project on https://pages.github.com/!!!!! That would allow us to include the documentation within the project.